### PR TITLE
Optionally pick the SUB-sense of a definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "curtiz-utils": "github:fasiha/curtiz-utils",
-        "kamiya-codec": "^4.6.2",
+        "kamiya-codec": "^4.8.0",
         "next": "12.1.6",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -2603,9 +2603,9 @@
       }
     },
     "node_modules/kamiya-codec": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/kamiya-codec/-/kamiya-codec-4.7.0.tgz",
-      "integrity": "sha512-PA0VluT8BohDobeymolebJ6ScGXTnPGSkJz2V0RD8aYoncxG11iM4rAsH6a7vKVEernkB3VlD2Ck6rQM12RTIA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/kamiya-codec/-/kamiya-codec-4.8.0.tgz",
+      "integrity": "sha512-BkTYCsPqtOOwzp7B0vHXomn4jQnz18JONqraFLwSZN8g2v822JiBQJXSIAZqmRo/IAXl2mWJMtXF7U9rF1Q0Lg=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
@@ -6025,9 +6025,9 @@
       }
     },
     "kamiya-codec": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/kamiya-codec/-/kamiya-codec-4.7.0.tgz",
-      "integrity": "sha512-PA0VluT8BohDobeymolebJ6ScGXTnPGSkJz2V0RD8aYoncxG11iM4rAsH6a7vKVEernkB3VlD2Ck6rQM12RTIA=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/kamiya-codec/-/kamiya-codec-4.8.0.tgz",
+      "integrity": "sha512-BkTYCsPqtOOwzp7B0vHXomn4jQnz18JONqraFLwSZN8g2v822JiBQJXSIAZqmRo/IAXl2mWJMtXF7U9rF1Q0Lg=="
     },
     "language-subtag-registry": {
       "version": "0.3.21",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "curtiz-utils": "github:fasiha/curtiz-utils",
-    "kamiya-codec": "^4.6.2",
+    "kamiya-codec": "^4.8.0",
     "next": "12.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/server/server.ts
+++ b/server/server.ts
@@ -22,7 +22,8 @@ app.get('/sentence/:sentence', async (req, res) => {
   const body = {
     sentence: req.params.sentence,
     nBest,
-    overrides: {'陽': [{ruby: '陽', rt: 'はる'}]}
+    overrides:
+        {'陽': [{ruby: '陽', rt: 'はる'}], '弦': [{ruby: '弦', rt: 'ゆずる'}]}
   };
   try {
     const reply = await fetch(


### PR DESCRIPTION
Recall that each entry in JMdict has multiple senses, each of which can have multiple glosses. So far in Kanda, we only connect a single sense of a given JMdict entry sense to text. However, for some words, you *really* want to specify the gloss or the "sub-sense", for example, https://jisho.org/search/覚%20おぼえる where the usual meanings of "to memorize" are in the *same* sense as "to remember".

Therefore now we can select this sub-sense while glossing to retain it in the database. We also display it in reading mode. This is fully backwards-compatible: you can elect to not provide a sub-sense, so all old data works fine.

## Before

### Glossing

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/37649/226795962-95cd8087-dace-42ff-8972-0f5a8fbb6f4e.png">

### Reading

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/37649/226796046-84c9903c-b4c1-4854-a543-6a65a850e69e.png">

## After

### Glossing

![image](https://user-images.githubusercontent.com/37649/226795858-881aa144-6b43-4edb-bcca-26b17c474e0d.png)

### Reading

![image](https://user-images.githubusercontent.com/37649/226796162-cfd7645b-2969-4a0c-8bd2-5e2a3e3c6541.png)
